### PR TITLE
[feat] Update Rrepresentative Model for Representative View

### DIFF
--- a/app/models/representative.rb
+++ b/app/models/representative.rb
@@ -17,8 +17,13 @@ class Representative < ApplicationRecord
         end
       end
 
-      rep = Representative.create!({ name: official.name, ocdid: ocdid_temp,
-          title: title_temp })
+      address = official.address.first
+      rep = Representative.create!(
+        name:  official.name, ocdid: ocdid_temp, title: title_temp,
+        street: address['line1'], city: address['city'], state: address['state'],
+        zip: address['zip'], party: official.party, photo: official.photoUrl
+      )
+
       reps.push(rep)
     end
 

--- a/spec/models/representative_spec.rb
+++ b/spec/models/representative_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe Representative, type: :model do
+  describe '.civic_api_to_representative_params' do
+    api_response = {
+      officials: [
+        OpenStruct.new({ name: 'Kevin Yoder',
+          address: [{ 'line1' => '215 Cannon HOB', 'city' => 'washington d.c.', 'state' => 'DC', 'zip' => '20515' }],
+          party: 'Republican', photoUrl: 'http://yoder.house.gov/images/user_images/headshot.jpg' })
+      ],
+      offices:   [OpenStruct.new({ name: 'Mayor', division_id: 'ocdid1', official_indices: [0] })]
+    }
+
+    before do
+      allow(described_class).to receive(:create!)
+    end
+
+    it 'creates representatives with additional address information' do
+      described_class.civic_api_to_representative_params(OpenStruct.new(api_response))
+      expect_create_with_attributes(
+        name: 'Kevin Yoder', ocdid: 'ocdid1', title: 'Mayor', street: '215 Cannon HOB', city: 'washington d.c.',
+        state: 'DC', zip: '20515', party: 'Republican', photo: 'http://yoder.house.gov/images/user_images/headshot.jpg'
+      )
+    end
+
+    def expect_create_with_attributes(attributes)
+      expect(described_class).to have_received(:create!).with(attributes).exactly(api_response[:officials].size).times
+    end
+  end
+end


### PR DESCRIPTION
Updated Representative model to include the fields contact address (street, city, state, zip), political party, and a photo as a part of Iter1 Part 2.